### PR TITLE
Media conversions optimization

### DIFF
--- a/app/Http/Controllers/MediaController.php
+++ b/app/Http/Controllers/MediaController.php
@@ -24,6 +24,10 @@ class MediaController extends Controller
             abort(404);
         }
 
+        if(!$this->isImageFile($file)){
+            return response()->file($originalPath);
+        }
+
         $path = $originalPath;
 
         $h = $this->roundImageSize($request->h);
@@ -89,5 +93,24 @@ class MediaController extends Controller
         }
 
         return 2800;
+    }
+
+    /**
+     * Checks if the given file string has an extension
+     * of a supported image file format.
+     * 
+     * @param string $file
+     * @return bool
+     */
+    protected function isImageFile(string $file){
+
+        $ext = strtolower(pathinfo($file, PATHINFO_EXTENSION));
+        $supportedFileFormats = ['jpg', 'jpeg', 'png', 'gif'];
+
+        if(!in_array($ext, $supportedFileFormats)){
+            return false;
+        }
+
+        return true;
     }
 }

--- a/app/Http/Controllers/MediaController.php
+++ b/app/Http/Controllers/MediaController.php
@@ -4,7 +4,6 @@ namespace App\Http\Controllers;
 
 use Illuminate\Http\Request;
 use Intervention\Image\Facades\Image;
-use Intervention\Image\ImageCache;
 
 class MediaController extends Controller
 {
@@ -18,24 +17,77 @@ class MediaController extends Controller
      */
     public function conversion(Request $request, $id, $file)
     {
-        $path = storage_path("app/public/{$id}/{$file}");
+        $originalPath = storage_path("app/public/{$id}/{$file}");
 
-        if (! file_exists($path)) {
+        // abort if original file does not exist
+        if (! file_exists($originalPath)) {
             abort(404);
         }
 
-        $img = Image::cache(function (ImageCache $image) use ($path, $request) {
-            $img = $image->make($path);
+        $path = $originalPath;
 
-            $h = $request->h;
-            $w = $request->w;
-            if ($h || $w) {
-                $img->resize($w, $h, function ($constraint) {
-                    $constraint->aspectRatio();
-                });
-            }
-        }, 60 * 24 * 365, true);
+        $h = $this->roundImageSize($request->h);
+        $w = $this->roundImageSize($request->w);
 
-        return $img->response();
+        if ($h) {
+            $path = ($this->addStringToFilename($path, '_h'.$h));
+        }
+        if ($w) {
+            $path = ($this->addStringToFilename($path, '_w'.$w));
+        }
+
+        // if the requested image size does exist, return it
+        if (file_exists($path)) {
+            return response()->file($path);
+        }
+
+        $img = Image::make($originalPath);
+
+        // if the image width is smaller than the requested width, don't upscale,
+        // use the original image.
+        if (($w != null && $w > $img->width()) || ($h != null && $h > $img->height())) {
+            return response()->file($originalPath);
+        }
+
+        $img->resize($w, $h, function ($constraint) {
+            $constraint->aspectRatio();
+        });
+
+        $img->save($path, 60);
+
+        return response()->file($path);
+    }
+
+    public function addStringToFilename($filename, $string)
+    {
+        $ext = pathinfo($filename, PATHINFO_EXTENSION);
+        $filename = str_replace('.'.$ext, '', $filename).$string.'.'.$ext;
+
+        return $filename;
+    }
+
+    public function roundImageSize(int|null $size = null)
+    {
+        if ($size == null) {
+            return;
+        }
+        if ($size < 10) {
+            return 10;
+        }
+        if ($size < 100) {
+            return (int) ceil($size / 10) * 10;
+        }
+        if ($size < 1600) {
+            $f = $size % 50;
+
+            return $size - $f + ($f > 0 ? 50 : 0);
+        }
+        if ($size < 2800) {
+            $f = $size % 100;
+
+            return $size - $f + ($f > 0 ? 100 : 0);
+        }
+
+        return 2800;
     }
 }

--- a/app/Http/Controllers/MediaConversionController.php
+++ b/app/Http/Controllers/MediaConversionController.php
@@ -5,7 +5,7 @@ namespace App\Http\Controllers;
 use Illuminate\Http\Request;
 use Intervention\Image\Facades\Image;
 
-class MediaController extends Controller
+class MediaConversionController extends Controller
 {
     /**
      * Get media conversions.
@@ -15,7 +15,7 @@ class MediaController extends Controller
      * @param  string  $file
      * @return void
      */
-    public function conversion(Request $request, $id, $file)
+    public function __invoke(Request $request, $id, $file)
     {
         $originalPath = storage_path("app/public/{$id}/{$file}");
 

--- a/routes/web.php
+++ b/routes/web.php
@@ -18,4 +18,4 @@ Route::get('/', function () {
     return view('welcome');
 });
 
-Route::get('/storage/c/{id}/{file}', [MediaController::class, 'conversion']);
+Route::get('/storage/c/{id}/{file}', [MediaController::class, 'conversion'])->withoutMiddleware('web');

--- a/routes/web.php
+++ b/routes/web.php
@@ -1,7 +1,7 @@
 <?php
 
-use App\Http\Controllers\MediaController;
 use Illuminate\Support\Facades\Route;
+use App\Http\Controllers\MediaConversionController;
 
 /*
 |--------------------------------------------------------------------------
@@ -18,4 +18,4 @@ Route::get('/', function () {
     return view('welcome');
 });
 
-Route::get('/storage/c/{id}/{file}', [MediaController::class, 'conversion'])->withoutMiddleware('web');
+Route::get('/storage/c/{id}/{file}', MediaConversionController::class)->withoutMiddleware('web');


### PR DESCRIPTION
This PR fixes a performance issue with generated media conversions.

The originally used `Invervention\ImageCache` doesn't work as expected. This is a problem we already discovered in the past and tried to find other approaches.

This is a refactoring and improvement of one of these approaches. Instead of trying to cache some generated conversions, we store conversions in storage and serve them from there.
The controller also includes some mechanics to prevent generating images huge conversions.
They are currently set to max out at 2800px or the max dimension of the source file.
With this a requested conversion is generated on the fly, which might take a few milliseconds on the first serve, but the images are served from storage on the next request.

As this approach still uses a controller to serve the images (and therefore the Laravel framework has to be booted in order to process the request) it's highly recommended to keep an eye on the booting time of your application.

The removal of the `web` middleware stack for the conversions controller route is a micro-optimization that can speed up the responses by up to ~ 60%.

