### PR TITLE
Update to Laravel 10

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ yarn-error.log
 /.idea
 /.vscode
 storage/debugbar
+/packages

--- a/composer.json
+++ b/composer.json
@@ -8,15 +8,13 @@
     ],
     "license": "MIT",
     "require": {
-        "php": "^8.0.2",
-        "aw-studio/laravel-redirects": "^0.3.0",
+        "php": "^8.1",
+        "aw-studio/laravel-redirects": "dev-main",
         "guzzlehttp/guzzle": "^7.2",
         "intervention/image": "^2.7",
-        "intervention/imagecache": "^2.5",
-        "laravel/framework": "^9.19",
+        "laravel/framework": "^10.0",
         "laravel/sanctum": "^3.0",
         "laravel/tinker": "^2.7",
-        "macramejs/admin-laravel": "dev-main",
         "macramejs/macrame-laravel": "dev-main"
     },
     "require-dev": {
@@ -25,9 +23,9 @@
         "laravel/pint": "^1.0",
         "laravel/sail": "^1.0.1",
         "mockery/mockery": "^1.4.4",
-        "nunomaduro/collision": "^6.1",
-        "phpunit/phpunit": "^9.5.10",
-        "spatie/laravel-ignition": "^1.0",
+        "nunomaduro/collision": "^7",
+        "phpunit/phpunit": "^10",
+        "spatie/laravel-ignition": "^2.0",
         "spatie/laravel-ray": "^1.32"
     },
     "autoload": {
@@ -75,6 +73,6 @@
             "pestphp/pest-plugin": true
         }
     },
-    "minimum-stability": "dev",
+    "minimum-stability": "stable",
     "prefer-stable": true
 }

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
     "license": "MIT",
     "require": {
         "php": "^8.1",
-        "aw-studio/laravel-redirects": "dev-main",
+        "aw-studio/laravel-redirects": "^0.4.0",
         "guzzlehttp/guzzle": "^7.2",
         "intervention/image": "^2.7",
         "laravel/framework": "^10.0",


### PR DESCRIPTION
This PR updates the package to use Laravel 10. Therefore PHP 8.1 now is a requirement too.

On this occasion I also removed `macramejs/admin-laravel` as with this setup it should no longer be required.

I have not noticed any other issues due to the upgrade.
